### PR TITLE
Don't capitalize words starting by a number (fabric renderer)

### DIFF
--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
@@ -378,6 +378,23 @@ AttributedStringBox RCTAttributedStringBoxFromNSAttributedString(NSAttributedStr
   return nsAttributedString.length ? AttributedStringBox{wrapManagedObject(nsAttributedString)} : AttributedStringBox{};
 }
 
+static NSString *capitalizeText(NSString *text)
+{
+  NSArray *words = [text componentsSeparatedByString:@" "];
+  NSMutableArray *newWords = [NSMutableArray new];
+  NSNumberFormatter *num = [NSNumberFormatter new];
+  for (NSString *item in words) {
+    NSString *word; 
+    if ([item length] > 0 && [num numberFromString:[item substringWithRange:NSMakeRange(0, 1)]] == nil) {
+      word = [item capitalizedString];
+    } else {
+      word = [item lowercaseString];
+    }
+    [newWords addObject:word];
+  }
+  return [newWords componentsJoinedByString:@" "];
+}
+
 NSString *RCTNSStringFromStringApplyingTextTransform(NSString *string, TextTransform textTransform)
 {
   switch (textTransform) {
@@ -386,7 +403,7 @@ NSString *RCTNSStringFromStringApplyingTextTransform(NSString *string, TextTrans
     case TextTransform::Lowercase:
       return [string lowercaseString];
     case TextTransform::Capitalize:
-      return [string capitalizedString];
+      return capitalizeText(string);
     default:
       return string;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Few month ago, I created a [pull request](https://github.com/facebook/react-native/pull/32774) to unify the behavior of capitalize style between Android and IOS. 

But, I found out that it doesn't work when fabric is enabled. We have the old behavior :
| Android | IOS |
| ------------- | ------------- |
| <img width="458" alt="capitalize_android_fabric" src="https://user-images.githubusercontent.com/40902940/163182082-4061003c-230b-46f7-9e93-c34b66dbf3d2.png"> | <img width="476" alt="capitalize_ios_fabric" src="https://user-images.githubusercontent.com/40902940/163182124-b6dee450-46e3-41a3-b5bb-553d7c2662e6.png"> |
(source: rn-tester, last commit: dac56ce)

As fabric is now live since v0.68, we should fix this behavior for fabric aswell. 

I don't know why there is so much duplicated code between `ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm` and `Libraries/Text/RCTTextAttributes.m` because I don't know the architecture of the project very well. But if you see missing tests or some refacto to do I'm open to suggestions!

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Don't capitalize the first letter of a word that is starting by a number (Fabric renderer)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I manually tested these changes on rn-tester (react-native `main` branch):
| Android | IOS |
| ------------- | ------------- |
| <img width="458" alt="capitalize_android_fabric" src="https://user-images.githubusercontent.com/40902940/163182082-4061003c-230b-46f7-9e93-c34b66dbf3d2.png"> | <img width="476" alt="capitalize_ios_fabric_after" src="https://user-images.githubusercontent.com/40902940/163184277-6c58c117-7144-4f6b-98ea-0c1db654f27b.png"> |